### PR TITLE
Update user install hashes

### DIFF
--- a/win32/ia32/user/latest.json
+++ b/win32/ia32/user/latest.json
@@ -1,1 +1,9 @@
-{ "url": "https://github.com/VSCodium/vscodium/releases/download/1.36.0/VSCodiumUserSetup-ia32-1.36.0.exe", "name": "1.36.0", "version": "0f3794b38477eea13fb47fbe15a42798e6129338", "productVersion": "1.36.0", "hash": "3cdc0370244b0a1e283815e936a62eb5ab0f2fda", "timestamp": "1562183366238", "sha256hash": "c35fa47f540824e6954037cd1b3127c85c98b45208fa78f469b97331bf1ed3d8" }
+{
+ "url": "https://github.com/VSCodium/vscodium/releases/download/1.36.0/VSCodiumUserSetup-ia32-1.36.0.exe",
+ "name": "1.36.0",
+ "version": "0f3794b38477eea13fb47fbe15a42798e6129338",
+ "productVersion": "1.36.0",
+ "hash": "df91a8365204753c1e78828e72d62f94c057bdea",
+ "timestamp": "1562183366238",
+ "sha256hash": "c38d26f705df7f5a53044652dc8134bb9a068340096bd0031cdc91689afdff26"
+ }

--- a/win32/x64/user/latest.json
+++ b/win32/x64/user/latest.json
@@ -1,1 +1,9 @@
-{ "url": "https://github.com/VSCodium/vscodium/releases/download/1.36.0/VSCodiumUserSetup-x64-1.36.0.exe", "name": "1.36.0", "version": "0f3794b38477eea13fb47fbe15a42798e6129338", "productVersion": "1.36.0", "hash": "206f24fb319bed625685b5347df6ac4221f95f36", "timestamp": "1562183538856", "sha256hash": "745fb68bc2f812e53c2b0e1cb38819891e38f5da2e169d6b2f64f51737bddefb" }
+{
+ "url": "https://github.com/VSCodium/vscodium/releases/download/1.36.0/VSCodiumUserSetup-x64-1.36.0.exe",
+ "name": "1.36.0",
+ "version": "0f3794b38477eea13fb47fbe15a42798e6129338",
+ "productVersion": "1.36.0",
+ "hash": "8df92a1bd40f30613a94d1b2ec157321a2d94ef0",
+ "timestamp": "1562183538856",
+ "sha256hash": "79ff93451617b2d768d8f341637cc85f407e9c22b58cc8f859699f8b77dd2d56"
+ }


### PR DESCRIPTION
Manually calculated hashes:

```bash
$ shasum -a 256 VSCodiumUserSetup-x64-1.36.0.exe
79ff93451617b2d768d8f341637cc85f407e9c22b58cc8f859699f8b77dd2d56  VSCodiumUserSetup-x64-1.36.0.exe
$ shasum -a 256 VSCodiumUserSetup-ia32-1.36.0.exe
c38d26f705df7f5a53044652dc8134bb9a068340096bd0031cdc91689afdff26  VSCodiumUserSetup-ia32-1.36.0.exe
$ shasum -a 1 VSCodiumUserSetup-ia32-1.36.0.exe
df91a8365204753c1e78828e72d62f94c057bdea  VSCodiumUserSetup-ia32-1.36.0.exe
$ shasum -a 1 VSCodiumUserSetup-x64-1.36.0.exe
8df92a1bd40f30613a94d1b2ec157321a2d94ef0  VSCodiumUserSetup-x64-1.36.0.exe
```